### PR TITLE
Fix interface path in openocd.cfg

### DIFF
--- a/nrf52832/armgcc/openocd.cfg
+++ b/nrf52832/armgcc/openocd.cfg
@@ -1,6 +1,6 @@
 #nRF52810 Target
 # source ./cmsis-dap.cfg
-source ./stlink-v2.cfg
+source [find interface/stlink-v2.cfg]
 # source [find interface/raspberrypi2-native.cfg]
 
 #set WORKAREASIZE 0x2000


### PR DESCRIPTION
The existing path requires an stlink-v2.cfg to be present in the current folder. The fix adjusts it to the openocd-supplied configuration files.